### PR TITLE
Add `_prepareWhiteConnection`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@netless/webview-bridge": "^0.1.11",
     "@netless/white-audio-plugin": "^1.2.4",
     "@netless/white-audio-plugin2": "^2.0.4",
+    "@netless/white-prepare": "^1.0.0",
     "@netless/white-video-plugin": "^1.2.4",
     "@netless/white-video-plugin2": "^2.0.4",
     "@netless/window-manager": "^0.4.69",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import App from "./App";
 import { addDebugFunctions } from "./Debug";
 import { WindowManager } from '@netless/window-manager';
 import { registerSDKBridge } from "./bridge/SDK";
+import { prepare } from "@netless/white-prepare";
 
 ReactDOM.render(
   <App />,
@@ -18,6 +19,8 @@ ReactDOM.render(
 registerSDKBridge();
 
 window.registerApp = WindowManager.register;
+
+window._prepareWhiteConnection = prepare;
 
 // Debug functions
 addDebugFunctions();

--- a/src/utils/ParamTypes.ts
+++ b/src/utils/ParamTypes.ts
@@ -31,5 +31,6 @@ declare global {
     appRegisterParams: AppRegisterParams[];
     nativeWebSocket?: boolean;
     syncedStore?: SyncedStore;
+    _prepareWhiteConnection: any;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,6 +1190,11 @@
   resolved "https://registry.yarnpkg.com/@netless/white-audio-plugin/-/white-audio-plugin-1.2.23.tgz#8867c4a90a23f297a8cb01701ce068846b847c67"
   integrity sha512-qwUVDhJheKaQnXiVIJVEuL5lMil82nIdBoh8QW4K/HFxWz8z4ok7xAOQj16nkH+3627Usk0YXKqK5RzErSSvCg==
 
+"@netless/white-prepare@^1.1.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@netless/white-prepare/-/white-prepare-1.0.1.tgz#a06e653e76c012be092fbdf203d515cf5366328b"
+  integrity sha512-SImcWbnq36S5+wNyzIc0etmKodrLmvuH5oKb9PN9Azctp7uiATTgnJvIQArrknS4zPYUumDUEDUOHHvXWrOd4g==
+
 "@netless/white-video-plugin2@^2.0.4":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@netless/white-video-plugin2/-/white-video-plugin2-2.0.5.tgz#13cc2497d640bd1b01cc56aa9930cbf0ffa84db1"


### PR DESCRIPTION
Native 中，在用户主动调用 prepare 的时候，加载一个 whiteboardView，然后执行这个 window. _prepareWhiteConnection。
这样能保证 localstorage 在同一个域名下，并且 iOS 能利用 webview 的加载缓存。
