### PR TITLE
Add `prepareWhiteConnection` for whiteSDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "whatwg-fetch": "^3.0.0",
-    "white-web-sdk": "2.16.50"
+    "white-web-sdk": "2.16.51"
   },
   "devDependencies": {
     "@babel/core": "^7.7.4",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@netless/webview-bridge": "^0.1.11",
     "@netless/white-audio-plugin": "^1.2.4",
     "@netless/white-audio-plugin2": "^2.0.4",
+    "@netless/white-prepare": "^1.0.0",
     "@netless/white-video-plugin": "^1.2.4",
     "@netless/white-video-plugin2": "^2.0.4",
     "@netless/window-manager": "^0.4.69",

--- a/src/bridge/SDK.ts
+++ b/src/bridge/SDK.ts
@@ -27,6 +27,7 @@ import { SDKCallbackHandler } from '../native/SDKCallbackHandler';
 import { destroySyncedStore, initSyncedStore } from './SyncedStore';
 import { SlideLoggerPlugin } from '../utils/SlideLogger';
 import { RtcAudioEffectClient } from '../RtcAudioEffectClient';
+import { prepare } from '@netless/white-prepare';
 
 let sdk: WhiteWebSdk | undefined = undefined;
 let room: Room | undefined = undefined;
@@ -473,5 +474,15 @@ class SDKBridge {
                 appOptions: para.appOptions
             }).then(() => responseCallback());
         }
+    }
+
+    prepareWhiteConnection = (params: PrepareParams, responseCallback: any) => {
+        const {appId, region, expire} = params;
+        const expireMS = expire || 12 * 3600 * 100;
+        prepare(appId, region as any, expireMS).then(() => {
+            responseCallback();
+        }).catch((e: Error) => {
+            responseCallback(JSON.stringify({__error: {message: e.message, jsStack: e.stack}}));
+        });
     }
 }

--- a/src/utils/ParamTypes.ts
+++ b/src/utils/ParamTypes.ts
@@ -1,11 +1,16 @@
 import { WindowManager } from '@netless/window-manager';
 import type { CombinePlayer } from "@netless/combine-player";
-import { WhiteWebSdk, Room, Player, } from 'white-web-sdk';
+import { WhiteWebSdk, Room, Player, WhiteWebSdkConfiguration, } from 'white-web-sdk';
 import { AppRegisterParams, PluginContext, PluginParams } from '@netless/whiteboard-bridge-types';
 import { SyncedStore } from '@netless/synced-store';
 import { RtcAudioEffectClient } from '../RtcAudioEffectClient';
 
 declare global {
+  interface PrepareParams {
+    appId: string;
+    region: string;
+    expire?: number;
+  }
   interface Window {
     room?: Room;
     manager?: WindowManager;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6733,10 +6733,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-white-web-sdk@2.16.50:
-  version "2.16.50"
-  resolved "https://registry.yarnpkg.com/white-web-sdk/-/white-web-sdk-2.16.50.tgz#9752cac4966bcc1786a6e0ac819a3bcdaaefcf04"
-  integrity sha512-K3D6wRMflPjeitjzCQXQNOKIdcZYTPGB3Ds3IIKmDlzU8G5/e9XytSBuGW++q4/XT3AMuP/xRe/xiZheLLo+3Q==
+white-web-sdk@2.16.51:
+  version "2.16.51"
+  resolved "https://registry.yarnpkg.com/white-web-sdk/-/white-web-sdk-2.16.51.tgz#f01a9b3000c491b4d15d78bc97ed4c802b0375fd"
+  integrity sha512-hEdqSMcaumf9w7Q8jb06Fluy83CP+32Cto9jih6EI/MZsy4feWf43u/GDXZhxOn5OnYzvSyxIx93O8vK/2xV8w==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@netless/canvas-polyfill" "^0.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,6 +1190,11 @@
   resolved "https://registry.yarnpkg.com/@netless/white-audio-plugin/-/white-audio-plugin-1.2.23.tgz#8867c4a90a23f297a8cb01701ce068846b847c67"
   integrity sha512-qwUVDhJheKaQnXiVIJVEuL5lMil82nIdBoh8QW4K/HFxWz8z4ok7xAOQj16nkH+3627Usk0YXKqK5RzErSSvCg==
 
+"@netless/white-prepare@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@netless/white-prepare/-/white-prepare-1.0.1.tgz#a06e653e76c012be092fbdf203d515cf5366328b"
+  integrity sha512-SImcWbnq36S5+wNyzIc0etmKodrLmvuH5oKb9PN9Azctp7uiATTgnJvIQArrknS4zPYUumDUEDUOHHvXWrOd4g==
+
 "@netless/white-video-plugin2@^2.0.4":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@netless/white-video-plugin2/-/white-video-plugin2-2.0.5.tgz#13cc2497d640bd1b01cc56aa9930cbf0ffa84db1"


### PR DESCRIPTION
Native 中，在用户主动调用 prepare 的时候，加载一个 whiteboardView，然后执行这个 sdk.prepareWhiteConnection 。
这样能保证 localstorage 在同一个域名下，并且 iOS 能利用 webview 的加载缓存。