### PR TITLE
Fix appliance worker rendering on legacy WebViews

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@netless/app-slide": "^0.2.99",
-    "@netless/appliance-plugin": "^1.1.38",
+    "@netless/appliance-plugin": "^1.1.39",
     "@netless/combine-player": "^1.1.1",
     "@netless/cursor-tool": "^0.1.1",
     "@netless/iframe-bridge": "2.1.9",
@@ -43,7 +43,7 @@
     "@netless/white-prepare": "^1.0.2",
     "@netless/white-video-plugin": "^1.2.4",
     "@netless/white-video-plugin2": "^2.0.4",
-    "@netless/window-manager": "1.0.17",
+    "@netless/window-manager": "1.0.18",
     "agora-foundation": "3.11.1-rc.1 || 3.11.1",
     "buffer": "^6.0.3",
     "core-js": "^3.33.3",

--- a/src/bridge/SDK.ts
+++ b/src/bridge/SDK.ts
@@ -29,7 +29,11 @@ import { SlideLoggerPlugin } from '../utils/SlideLogger';
 import { RtcAudioEffectClient } from '../RtcAudioEffectClient';
 import { prepare } from '@netless/white-prepare';
 
-import { ApplianceMultiPlugin } from '@netless/appliance-plugin';
+import {
+    ApplianceMultiPlugin,
+    WorkerCanvasContextBlacklistLevel,
+    WorkerRenderModeBlacklistLevel,
+} from '@netless/appliance-plugin';
 import fullWorkerString from '@netless/appliance-plugin/dist/fullWorker.js?raw';
 import subWorkerString from '@netless/appliance-plugin/dist/subWorker.js?raw';
 import { createWorkerInstance as createFoundationWorkerInstance } from '../FoundationWorkerFactory';
@@ -106,6 +110,51 @@ const logTruncatedSuffix = "...";
 let disposeLocalLogStateChange: (() => void) | undefined;
 let applianceFullWorkerBlobUrl: string | undefined;
 let applianceSubWorkerBlobUrl: string | undefined;
+
+const defaultAppliancePluginOptions = {
+    workerRenderModeBlacklist: {
+        androidWebView: {
+            "89": WorkerRenderModeBlacklistLevel.OffscreenTransfer,
+        },
+        harmonyArkWeb: {
+            "99": WorkerRenderModeBlacklistLevel.OffscreenTransfer,
+        },
+        iosWebView: {
+            "12": WorkerRenderModeBlacklistLevel.ImageBitmap,
+            "16": WorkerRenderModeBlacklistLevel.OffscreenTransfer,
+        },
+    },
+    workerCanvasContextBlacklist: {
+        androidWebView: {
+            "89": WorkerCanvasContextBlacklistLevel.WebGL,
+        },
+        harmonyArkWeb: {
+            "99": WorkerCanvasContextBlacklistLevel.WebGL,
+        },
+        iosWebView: {
+            "16": WorkerCanvasContextBlacklistLevel.WebGL,
+        },
+    },
+};
+
+function mergeAppliancePluginOptions(appliancePluginOptions?: Record<string, any>): Record<string, any> {
+    const appliancePluginExtras = appliancePluginOptions?.extras;
+
+    return {
+        ...appliancePluginOptions,
+        extras: {
+            ...appliancePluginExtras,
+            workerRenderModeBlacklist: {
+                ...defaultAppliancePluginOptions.workerRenderModeBlacklist,
+                ...appliancePluginExtras?.workerRenderModeBlacklist,
+            },
+            workerCanvasContextBlacklist: {
+                ...defaultAppliancePluginOptions.workerCanvasContextBlacklist,
+                ...appliancePluginExtras?.workerCanvasContextBlacklist,
+            },
+        },
+    };
+}
 
 export function registerSDKBridge() {
     const sdk = new SDKBridge();
@@ -548,6 +597,12 @@ class SDKBridge {
                     if (nativeConfig?.enableAppliancePlugin) {
                         const applianceWorkerUrls = getApplianceWorkerUrls();
                         const roomLogger = (room as unknown as { logger?: { info(message: string): void; error(message: string): void } }).logger;
+                        const mergedAppliancePluginOptions = mergeAppliancePluginOptions(appliancePluginOptions);
+                        const mergedAppliancePluginExtras = mergedAppliancePluginOptions.extras;
+                        roomLogger?.info(`[Bridge] ApplianceMultiPlugin blacklists: ${JSON.stringify({
+                            workerRenderModeBlacklist: mergedAppliancePluginExtras.workerRenderModeBlacklist,
+                            workerCanvasContextBlacklist: mergedAppliancePluginExtras.workerCanvasContextBlacklist,
+                        })}`);
                         roomLogger?.info("[Bridge] ApplianceMultiPlugin.getInstance start");
                         try {
                             const plugin = await ApplianceMultiPlugin.getInstance(manager,
@@ -557,7 +612,7 @@ class SDKBridge {
                                             fullWorkerUrl: applianceWorkerUrls.fullWorkerUrl,
                                             subWorkerUrl: applianceWorkerUrls.subWorkerUrl,
                                         },
-                                        ...appliancePluginOptions,
+                                        ...mergedAppliancePluginOptions,
                                     }
                                 }
                             );

--- a/src/bridge/SDK.ts
+++ b/src/bridge/SDK.ts
@@ -323,21 +323,30 @@ function toBuiltinAppOptions(options?: NativeBuiltinAppOptions) {
 }
 
 async function mountWindowManager(room: Room, handler: RoomCallbackHandler | ReplayerCallbackHandler, windowParams?: NativeWindowParams) {
+    const roomLogger = (room as unknown as { logger?: { info(message: string): void; error(message: string): void } }).logger;
     const { builtinAppOptions, ...restWindowParams } = windowParams || {};
     const presentation = builtinAppOptions?.presentation ?? nativeConfig?.presentationAppOptions;
-    const manager = await WindowManager.mount({
-        // 高比宽
-        containerSizeRatio: 9/16,
-        chessboard: true,
-        cursor: !!cursorAdapter,
-        supportAppliancePlugin: nativeConfig?.enableAppliancePlugin,
-        ...restWindowParams,
-        builtinAppOptions: toBuiltinAppOptions(
-            presentation ? { presentation } : undefined
-        ),
-        container: divRef(),
-        room,
-    } as MountParams);
+    roomLogger?.info("[Bridge] WindowManager.mount start");
+    let manager: WindowManager;
+    try {
+        manager = await WindowManager.mount({
+            // 高比宽
+            containerSizeRatio: 9/16,
+            chessboard: true,
+            cursor: !!cursorAdapter,
+            supportAppliancePlugin: nativeConfig?.enableAppliancePlugin,
+            ...restWindowParams,
+            builtinAppOptions: toBuiltinAppOptions(
+                presentation ? { presentation } : undefined
+            ),
+            container: divRef(),
+            room,
+        } as MountParams);
+        roomLogger?.info("[Bridge] WindowManager.mount success");
+    } catch (error) {
+        roomLogger?.error(`[Bridge] WindowManager.mount failed: ${error?.message || error}`);
+        throw error;
+    }
     addManagerListener(manager, logger, handler);
     return manager;
 }
@@ -538,18 +547,26 @@ class SDKBridge {
 
                     if (nativeConfig?.enableAppliancePlugin) {
                         const applianceWorkerUrls = getApplianceWorkerUrls();
-                        const plugin = await ApplianceMultiPlugin.getInstance(manager,
-                            {
-                                options: {
-                                    cdn: {
-                                        fullWorkerUrl: applianceWorkerUrls.fullWorkerUrl,
-                                        subWorkerUrl: applianceWorkerUrls.subWorkerUrl,
-                                    },
-                                    ...appliancePluginOptions,
+                        const roomLogger = (room as unknown as { logger?: { info(message: string): void; error(message: string): void } }).logger;
+                        roomLogger?.info("[Bridge] ApplianceMultiPlugin.getInstance start");
+                        try {
+                            const plugin = await ApplianceMultiPlugin.getInstance(manager,
+                                {
+                                    options: {
+                                        cdn: {
+                                            fullWorkerUrl: applianceWorkerUrls.fullWorkerUrl,
+                                            subWorkerUrl: applianceWorkerUrls.subWorkerUrl,
+                                        },
+                                        ...appliancePluginOptions,
+                                    }
                                 }
-                            }
-                        );
-                        window.appliancePlugin = plugin;
+                            );
+                            window.appliancePlugin = plugin;
+                            roomLogger?.info("[Bridge] ApplianceMultiPlugin.getInstance success");
+                        } catch (error) {
+                            roomLogger?.error(`[Bridge] ApplianceMultiPlugin.getInstance failed: ${error?.message || error}`);
+                            throw error;
+                        }
                     }
                 } catch (error) {
                     return responseCallback(JSON.stringify({__error: {message: error.message, jsStack: error.stack}}));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,9 @@ config = {
   target: ["web", "es5"],
   resolve: {
     alias: {
+      // rbush v4 ships an ESM entry that the legacy Babel pipeline rewrites to
+      // bare CommonJS globals. Use its official browser bundle in WebView builds.
+      "rbush$": path.join(path.dirname(require.resolve("rbush")), "rbush.min.js"),
       "@netless/window-manager/dist/style.css": require.resolve("@netless/window-manager").replace("index.js", "style.css"),
       "@netless/window-manager": require.resolve("@netless/window-manager"),
 
@@ -89,6 +92,10 @@ config = {
   module: {
     rules: [
       {
+        test: /node_modules[\\/]rbush[\\/]rbush\.min\.js$/,
+        type: "javascript/auto",
+      },
+      {
         test: /\.(ts|js|cjs)x?$/,
         resourceQuery: { not: [/raw/] },
         use: [
@@ -117,6 +124,7 @@ config = {
     buildDependencies: {
       config: [
         __filename,
+        path.join(__dirname, 'babel.config.js'),
         path.join(__dirname, '.generated/foundation-worker.js'),
         path.join(__dirname, '.generated/foundation-worker.manifest.json'),
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,13 +971,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.4.5", "@babel/runtime@^7.7.6":
-  version "7.24.7"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz"
-  integrity sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
 "@babel/runtime@^7.5.5", "@babel/runtime@^7.9.2":
   version "7.12.5"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz"
@@ -1116,34 +1109,15 @@
   resolved "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz"
   integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
 
-"@mesh.js/core@^1.1.23":
-  version "1.1.25"
-  resolved "https://registry.npmjs.org/@mesh.js/core/-/core-1.1.25.tgz"
-  integrity sha512-Jxn0EGEbADruAVSgpLbX9S6j3GVeat7QvElc+zU8boFI4TyR5MhAMDTKM5VnCnWmExJByS5KN1EHs5tvYocFnA==
-  dependencies:
-    "@babel/runtime" "^7.4.5"
-    abs-svg-path "^0.1.1"
-    adaptive-bezier-curve "^1.0.3"
-    as-number "^1.0.0"
-    bound-points "^1.0.0"
-    color-rgba "^2.1.1"
-    gl-matrix "^3.1.0"
-    gl-renderer "^0.13.5"
-    parse-svg-path "^0.1.2"
-    polyline-miter-util "^1.0.1"
-    simplify-path "^1.1.0"
-    tess2 "^1.0.0"
-    xtend "^4.0.2"
-
 "@netless/app-slide@^0.2.99":
   version "0.2.99"
   resolved "https://registry.npmjs.org/@netless/app-slide/-/app-slide-0.2.99.tgz#0d9067ed426ee35ed942188b62740ba249d2333c"
   integrity sha512-GFzjoWh/Jp/bh5dXO+coszQmPioRvp/vK+Ac8N/OCry7AS2Oh8RTscNRnVg9j08+7L7m9GjK1JZA8NqcORXFBQ==
 
-"@netless/appliance-plugin@^1.1.38":
-  version "1.1.38"
-  resolved "https://registry.npmjs.org/@netless/appliance-plugin/-/appliance-plugin-1.1.38.tgz#5fe00621eb6fe8c887d70fbf0ded45a0bb135b3f"
-  integrity sha512-qZyzDv2OjqIYj8Q6acMhGIQFJQx7lbeDp9ITI6B6CMbj6ClXaPrHBlkGdPnWFWFUhoDZKcm3BV2mY2vqtzpdqA==
+"@netless/appliance-plugin@^1.1.39":
+  version "1.1.39"
+  resolved "https://registry.npmjs.org/@netless/appliance-plugin/-/appliance-plugin-1.1.39.tgz#bf5ed1c02673c4cb68223b52f812f55aaa994a4b"
+  integrity sha512-cnzHqGplg9HIWYLJwaJVOUqPzrlm9y2rhPePiZKYT+WERTaDlhaY0/NGgHEN8G8rqIR23hx9iP/K7drejtIh0w==
   dependencies:
     clipper-lib "^6.4.2"
     dom-to-image "^2.6.0"
@@ -1151,11 +1125,11 @@
     lineclip "^1.1.5"
     lodash "^4.17.21"
     lz-string "^1.5.0"
+    rbush "4.0.1"
     re-resizable "^6.9.11"
     react "^16.8.0"
     react-dom "^16.8.0"
     react-draggable "4.5.0"
-    spritejs "^3.8.3"
     xss "^1.0.15"
 
 "@netless/canvas-polyfill@^0.0.4":
@@ -1247,10 +1221,10 @@
   resolved "https://registry.npmjs.org/@netless/whiteboard-bridge-types/-/whiteboard-bridge-types-0.1.13.tgz"
   integrity sha512-ZfJt/fD824oqLFW6Jl09cpWB9t30G+lwSUzLiWI1PpakhdlxX3lC9XMH8FtWGghYbzzXFEDh6Ay2N02F87II7g==
 
-"@netless/window-manager@1.0.17":
-  version "1.0.17"
-  resolved "https://registry.npmjs.org/@netless/window-manager/-/window-manager-1.0.17.tgz#c73acba44b0506dd17ddbbd7c4abd94cea8045a6"
-  integrity sha512-VuV71zJKUZaeV9orV16t3rVCxDi/ge5hZABVgP9rsRpMTBz/DqKTz7T3/jFaZYzkeDcl24wC7hdznAGOHprcLQ==
+"@netless/window-manager@1.0.18":
+  version "1.0.18"
+  resolved "https://registry.npmjs.org/@netless/window-manager/-/window-manager-1.0.18.tgz#463ad2f2115b7b90f985b0b1e79f61856ea65915"
+  integrity sha512-tCxJMVJtVGjXE1dnhcb2EIFDhEk9Izam+TuW3P8UWHpamFEsCLFA7XpGOjWw6iw3EPxk7RWYI55mACrEX6ZZ8w==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@netless/telebox-insider" "0.3.0"
@@ -1767,11 +1741,6 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-abs-svg-path@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz"
-  integrity sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==
-
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz"
@@ -1789,11 +1758,6 @@ acorn@^8.4.1:
   version "8.7.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
-
-adaptive-bezier-curve@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/adaptive-bezier-curve/-/adaptive-bezier-curve-1.0.3.tgz"
-  integrity sha512-mDcwN284LlNAdunqnVmS0PAoDNHKze/PY8zvpCdxzyXD+ZZFeMWQ3FKNBw0VMOd9IfnhIyzAWJDXzRcWnXtoSg==
 
 aes-decrypter@3.0.2:
   version "3.0.2"
@@ -1968,11 +1932,6 @@ array.prototype.map@^1.0.1:
     es-array-method-boxes-properly "^1.0.0"
     is-string "^1.0.4"
 
-as-number@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/as-number/-/as-number-1.0.0.tgz"
-  integrity sha512-HkI/zLo2AbSRO4fqVkmyf3hms0bJDs3iboHqTrNuwTiCRvdYXM7HFhfhB6Dk51anV2LM/IMB83mtK9mHw4FlAg==
-
 asn1@~0.2.3:
   version "0.2.6"
   resolved "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz"
@@ -2062,14 +2021,6 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
-babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
-  integrity sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
@@ -2106,11 +2057,6 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
   dependencies:
     tweetnacl "^0.14.3"
-
-bezier-easing@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz"
-  integrity sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==
 
 bezier-js@^2.4.4:
   version "2.6.1"
@@ -2165,15 +2111,10 @@ bonjour@^3.5.0:
     multicast-dns "^6.0.1"
     multicast-dns-service-types "^1.1.0"
 
-boolbase@^1.0.0, boolbase@~1.0.0:
+boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
-
-bound-points@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/bound-points/-/bound-points-1.0.0.tgz"
-  integrity sha512-D5v3yrtBvia09U2+Js73YMswySOclYHuXNFFzYvsigAdqpY5YG+kY4cSHi7Mww6yU8N8u0T1XkMkRGgeDdWqBA==
 
 bowser@^2.11.0:
   version "2.11.0"
@@ -2461,26 +2402,6 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-parse@^1.4.2:
-  version "1.4.3"
-  resolved "https://registry.npmjs.org/color-parse/-/color-parse-1.4.3.tgz"
-  integrity sha512-BADfVl/FHkQkyo8sRBwMYBqemqsgnu7JZAwUgvBvuwwuNUZAhSvLTbsEErS5bQXzOjDR0dWzJ4vXN2Q+QoPx0A==
-  dependencies:
-    color-name "^1.0.0"
-
-color-rgba@^2.1.1:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/color-rgba/-/color-rgba-2.4.0.tgz"
-  integrity sha512-Nti4qbzr/z2LbUWySr7H9dk3Rl7gZt7ihHAxlgT4Ho90EXWkjtkL1avTleu9yeGuqrt/chxTB6GKK8nZZ6V0+Q==
-  dependencies:
-    color-parse "^1.4.2"
-    color-space "^2.0.0"
-
-color-space@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz"
-  integrity sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA==
-
 color-string@^1.9.0:
   version "1.9.1"
   resolved "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz"
@@ -2631,11 +2552,6 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.5"
     semver "7.0.0"
 
-core-js@^2.4.0:
-  version "2.6.12"
-  resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
-
 core-js@^3.15.2:
   version "3.16.0"
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.16.0.tgz"
@@ -2717,16 +2633,6 @@ css-minimizer-webpack-plugin@^3.4.1:
     serialize-javascript "^6.0.0"
     source-map "^0.6.1"
 
-css-select@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz"
-  integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
-  dependencies:
-    boolbase "^1.0.0"
-    css-what "^3.2.1"
-    domutils "^1.7.0"
-    nth-check "^1.0.2"
-
 css-select@^4.1.3:
   version "4.2.1"
   resolved "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz"
@@ -2745,11 +2651,6 @@ css-tree@^1.1.2, css-tree@^1.1.3:
   dependencies:
     mdn-data "2.0.14"
     source-map "^0.6.1"
-
-css-what@^3.2.1:
-  version "3.4.2"
-  resolved "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz"
-  integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
 
 css-what@^5.1.0:
   version "5.1.0"
@@ -3099,14 +3000,6 @@ dom-converter@^0.2.0:
   dependencies:
     utila "~0.4"
 
-dom-serializer@0:
-  version "0.2.2"
-  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz"
-  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
-  dependencies:
-    domelementtype "^2.0.1"
-    entities "^2.0.0"
-
 dom-serializer@^1.0.1:
   version "1.3.2"
   resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz"
@@ -3125,11 +3018,6 @@ dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz"
   integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
-
-domelementtype@1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz"
-  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
 domelementtype@^2.0.1:
   version "2.0.1"
@@ -3152,14 +3040,6 @@ dompurify@^2.2.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/dompurify/-/dompurify-2.4.1.tgz"
   integrity sha512-ewwFzHzrrneRjxzmK6oVz/rZn9VWspGFRDb4/rRtIsM1n36t9AKma/ye8syCpcw+XJ25kOK/hOG7t1j2I2yBqA==
-
-domutils@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz"
-  integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
 
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
@@ -3741,23 +3621,6 @@ getpass@^0.1.1:
   integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
   dependencies:
     assert-plus "^1.0.0"
-
-gl-matrix@^3.1.0:
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz"
-  integrity sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==
-
-gl-renderer@^0.13.5:
-  version "0.13.6"
-  resolved "https://registry.npmjs.org/gl-renderer/-/gl-renderer-0.13.6.tgz"
-  integrity sha512-FaD9JFb6tabjkExpeQnVkT4fNJJMb01yuBvyPGa1N4V/wEVHvwDoEDiKEkqvC+I4fj1GNV0uQoT58jRmK/sHvQ==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
-
-gl-vec2@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/gl-vec2/-/gl-vec2-1.3.0.tgz"
-  integrity sha512-YiqaAuNsheWmUV0Sa8k94kBB0D6RWjwZztyO+trEYS8KzJ6OQB/4686gdrf59wld4hHFIvaxynO3nRxpk1Ij/A==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -4936,13 +4799,6 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-nth-check@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz"
-  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
-  dependencies:
-    boolbase "~1.0.0"
-
 nth-check@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz"
@@ -5087,11 +4943,6 @@ param-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-parse-svg-path@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz"
-  integrity sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==
-
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
@@ -5104,11 +4955,6 @@ pascal-case@^3.1.2:
   dependencies:
     no-case "^3.0.4"
     tslib "^2.0.3"
-
-pasition@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/pasition/-/pasition-1.0.3.tgz"
-  integrity sha512-hsUNLhS7e5uWGkTtgbxoHMzCUb0PeboQelyqPmpRkAk26AkKal0Z6JfYWhjIEhZHIYzJTfr6Aom/BpBPrZXHnA==
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -5219,13 +5065,6 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-polyline-miter-util@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/polyline-miter-util/-/polyline-miter-util-1.0.1.tgz"
-  integrity sha512-/3u91zz6mBerBZo6qnOJOTjv7EfPhKtsV028jMyj86YpzLRNmCCFfrX7IO9tCEQ2W4x45yc+vKOezjf7u2Nd6Q==
-  dependencies:
-    gl-vec2 "^1.0.0"
 
 portfinder@^1.0.28:
   version "1.0.28"
@@ -5658,6 +5497,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quickselect@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz#a37fc953867d56f095a20ac71c6d27063d2de603"
+  integrity sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz"
@@ -5686,6 +5530,13 @@ raw-body@2.4.0:
     http-errors "1.7.2"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+rbush@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz#1f55afa64a978f71bf9e9a99bc14ff84f3cb0d6d"
+  integrity sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==
+  dependencies:
+    quickselect "^3.0.0"
 
 re-resizable@^6.9.11:
   version "6.9.17"
@@ -5785,11 +5636,6 @@ regenerate@^1.4.0:
   resolved "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
 regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.7:
   version "0.13.11"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz"
@@ -5799,11 +5645,6 @@ regenerator-runtime@^0.13.4:
   version "0.13.7"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
-
-regenerator-runtime@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz"
-  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regenerator-transform@^0.14.2:
   version "0.14.4"
@@ -6183,11 +6024,6 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-simplify-path@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/simplify-path/-/simplify-path-1.1.0.tgz"
-  integrity sha512-qvEyrV36pP6YjRoEAe7ymSqFwurrTQXltcmZaQXFVh8cTWUfHYGeobbMK8V7WHlT9+ysW3GNVkCd6TF8aM0ydw==
-
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
@@ -6287,35 +6123,6 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
-
-sprite-animator@^1.11.5:
-  version "1.11.5"
-  resolved "https://registry.npmjs.org/sprite-animator/-/sprite-animator-1.11.5.tgz"
-  integrity sha512-YqYLYYgyvrhXTF4aYyXb0NfdS4uBSKIYKwbBgAKCSsw6sogcgShWoNnV4SgOtI250kIUS/dZH0OZ+lgbCBgAGA==
-  dependencies:
-    babel-runtime "^6.26.0"
-    bezier-easing "^2.0.3"
-    sprite-timeline "^1.10.2"
-
-sprite-timeline@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.npmjs.org/sprite-timeline/-/sprite-timeline-1.10.2.tgz"
-  integrity sha512-Nu0SNxSy04tyZELMYEjvKVN/2KoluLIXj4qHGrNSLKmQX9sPDegg2EzhnpP50FKQQAEDPHgrYlg3MuQA3cVW1g==
-  dependencies:
-    babel-runtime "^6.26.0"
-
-spritejs@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.npmjs.org/spritejs/-/spritejs-3.8.3.tgz"
-  integrity sha512-Ar+BKZlgFBv9sAICzNJH2QV4HCKiq/opwz3DUH5/NtvBzGALsG62BTZNtzssjtQY6QLacC9BPWCdAhrngejYDA==
-  dependencies:
-    "@babel/runtime" "^7.4.5"
-    "@mesh.js/core" "^1.1.23"
-    color-rgba "^2.1.1"
-    css-select "^2.0.2"
-    gl-matrix "^3.1.0"
-    pasition "^1.0.2"
-    sprite-animator "^1.11.5"
 
 sshpk@^1.14.1:
   version "1.17.0"
@@ -6539,11 +6346,6 @@ terser@^5.10.0, terser@^5.7.2:
     commander "^2.20.0"
     source-map "~0.7.2"
     source-map-support "~0.5.20"
-
-tess2@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/tess2/-/tess2-1.0.0.tgz"
-  integrity sha512-iSWBSOUoPn3cCT26L5Wi6mvVgL11RV4kReSnVIIPdMN7qNpkL5SLKen5BJcWj+ZTN7kK6JrHBdqTV7vvL8g+9w==
 
 text-segmentation@^1.0.2:
   version "1.0.2"
@@ -7097,11 +6899,6 @@ xss@^1.0.15:
   dependencies:
     commander "^2.20.3"
     cssfilter "0.0.10"
-
-xtend@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz"
-  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary
- update whiteboard dependencies and appliance initialization logs
- bundle rbush for legacy WebViews
- configure appliance worker render/context blacklists in Bridge defaults
- merge host blacklist overrides at the runtime level under appliance options.extras

## Verification
- yarn run check
- yarn build
- Android WebView 71: worker-image-bitmap + 2d, room connected and rendered