### PR TITLE
chore: upgrade appliance plugin to 1.1.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@netless/app-slide": "^0.2.99",
-    "@netless/appliance-plugin": "^1.1.39",
+    "@netless/appliance-plugin": "^1.1.40",
     "@netless/combine-player": "^1.1.1",
     "@netless/cursor-tool": "^0.1.1",
     "@netless/iframe-bridge": "2.1.9",

--- a/src/bridge/SDK.ts
+++ b/src/bridge/SDK.ts
@@ -29,11 +29,7 @@ import { SlideLoggerPlugin } from '../utils/SlideLogger';
 import { RtcAudioEffectClient } from '../RtcAudioEffectClient';
 import { prepare } from '@netless/white-prepare';
 
-import {
-    ApplianceMultiPlugin,
-    WorkerCanvasContextBlacklistLevel,
-    WorkerRenderModeBlacklistLevel,
-} from '@netless/appliance-plugin';
+import { ApplianceMultiPlugin } from '@netless/appliance-plugin';
 import fullWorkerString from '@netless/appliance-plugin/dist/fullWorker.js?raw';
 import subWorkerString from '@netless/appliance-plugin/dist/subWorker.js?raw';
 import { createWorkerInstance as createFoundationWorkerInstance } from '../FoundationWorkerFactory';
@@ -110,51 +106,6 @@ const logTruncatedSuffix = "...";
 let disposeLocalLogStateChange: (() => void) | undefined;
 let applianceFullWorkerBlobUrl: string | undefined;
 let applianceSubWorkerBlobUrl: string | undefined;
-
-const defaultAppliancePluginOptions = {
-    workerRenderModeBlacklist: {
-        androidWebView: {
-            "89": WorkerRenderModeBlacklistLevel.OffscreenTransfer,
-        },
-        harmonyArkWeb: {
-            "99": WorkerRenderModeBlacklistLevel.OffscreenTransfer,
-        },
-        iosWebView: {
-            "12": WorkerRenderModeBlacklistLevel.ImageBitmap,
-            "16": WorkerRenderModeBlacklistLevel.OffscreenTransfer,
-        },
-    },
-    workerCanvasContextBlacklist: {
-        androidWebView: {
-            "89": WorkerCanvasContextBlacklistLevel.WebGL,
-        },
-        harmonyArkWeb: {
-            "99": WorkerCanvasContextBlacklistLevel.WebGL,
-        },
-        iosWebView: {
-            "16": WorkerCanvasContextBlacklistLevel.WebGL,
-        },
-    },
-};
-
-function mergeAppliancePluginOptions(appliancePluginOptions?: Record<string, any>): Record<string, any> {
-    const appliancePluginExtras = appliancePluginOptions?.extras;
-
-    return {
-        ...appliancePluginOptions,
-        extras: {
-            ...appliancePluginExtras,
-            workerRenderModeBlacklist: {
-                ...defaultAppliancePluginOptions.workerRenderModeBlacklist,
-                ...appliancePluginExtras?.workerRenderModeBlacklist,
-            },
-            workerCanvasContextBlacklist: {
-                ...defaultAppliancePluginOptions.workerCanvasContextBlacklist,
-                ...appliancePluginExtras?.workerCanvasContextBlacklist,
-            },
-        },
-    };
-}
 
 export function registerSDKBridge() {
     const sdk = new SDKBridge();
@@ -597,12 +548,6 @@ class SDKBridge {
                     if (nativeConfig?.enableAppliancePlugin) {
                         const applianceWorkerUrls = getApplianceWorkerUrls();
                         const roomLogger = (room as unknown as { logger?: { info(message: string): void; error(message: string): void } }).logger;
-                        const mergedAppliancePluginOptions = mergeAppliancePluginOptions(appliancePluginOptions);
-                        const mergedAppliancePluginExtras = mergedAppliancePluginOptions.extras;
-                        roomLogger?.info(`[Bridge] ApplianceMultiPlugin blacklists: ${JSON.stringify({
-                            workerRenderModeBlacklist: mergedAppliancePluginExtras.workerRenderModeBlacklist,
-                            workerCanvasContextBlacklist: mergedAppliancePluginExtras.workerCanvasContextBlacklist,
-                        })}`);
                         roomLogger?.info("[Bridge] ApplianceMultiPlugin.getInstance start");
                         try {
                             const plugin = await ApplianceMultiPlugin.getInstance(manager,
@@ -612,7 +557,7 @@ class SDKBridge {
                                             fullWorkerUrl: applianceWorkerUrls.fullWorkerUrl,
                                             subWorkerUrl: applianceWorkerUrls.subWorkerUrl,
                                         },
-                                        ...mergedAppliancePluginOptions,
+                                        ...appliancePluginOptions,
                                     }
                                 }
                             );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,10 +1114,10 @@
   resolved "https://registry.npmjs.org/@netless/app-slide/-/app-slide-0.2.99.tgz#0d9067ed426ee35ed942188b62740ba249d2333c"
   integrity sha512-GFzjoWh/Jp/bh5dXO+coszQmPioRvp/vK+Ac8N/OCry7AS2Oh8RTscNRnVg9j08+7L7m9GjK1JZA8NqcORXFBQ==
 
-"@netless/appliance-plugin@^1.1.39":
-  version "1.1.39"
-  resolved "https://registry.npmjs.org/@netless/appliance-plugin/-/appliance-plugin-1.1.39.tgz#bf5ed1c02673c4cb68223b52f812f55aaa994a4b"
-  integrity sha512-cnzHqGplg9HIWYLJwaJVOUqPzrlm9y2rhPePiZKYT+WERTaDlhaY0/NGgHEN8G8rqIR23hx9iP/K7drejtIh0w==
+"@netless/appliance-plugin@^1.1.40":
+  version "1.1.40"
+  resolved "https://registry.npmjs.org/@netless/appliance-plugin/-/appliance-plugin-1.1.40.tgz#601452f62c6021bd25af27feb8e3ccfb66ca5906"
+  integrity sha512-GgcIY3aU0ReR/mGntSlxx+bZYOiqb75rjnRUC6pW0dRph1xaYopIwT9nezMasNWP5g4zJHCje60F0uVl9mjCgA==
   dependencies:
     clipper-lib "^6.4.2"
     dom-to-image "^2.6.0"


### PR DESCRIPTION
## Summary
- upgrade `@netless/appliance-plugin` from 1.1.39 to 1.1.40
- let the plugin own default worker render and canvas context compatibility policies
- continue passing host `appliancePluginOptions` through unchanged

## Validation
- `yarn install --frozen-lockfile --offline`
- `yarn build`